### PR TITLE
Fix typos and Prisma queries

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken'
 import { prisma } from '../db.js'
-import { validatePassword } from '../tools/secutity.js'
+import { encryptPassword, validatePassword } from '../tools/security.js'
 import { PRIVATE_KEY } from '../config.js'
 
 // ✅ REGISTRO

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -15,8 +15,13 @@ export const getUsers = async (req, res) => {
 
   console.log('Consulta desde la base de datos')
   const users = await prisma.user.findMany({
-    omit: {
-      password: true
+    select: {
+      id: true,
+      username: true,
+      name: true,
+      email: true,
+      isActive: true,
+      createdAt: true
     }
   })
   cache.set(cacheKeyAllUsers, users)
@@ -26,7 +31,14 @@ export const getUsers = async (req, res) => {
 export const getUserById = async (req, res) => {
   const user = await prisma.user.findUnique({
     where: { id: Number(req.params.id) },
-    omit: { password: true }
+    select: {
+      id: true,
+      username: true,
+      name: true,
+      email: true,
+      isActive: true,
+      createdAt: true
+    }
   })
 
   if (!user) {
@@ -53,9 +65,10 @@ export const createUser = async (req, res) => {
   newUser.password = hashPassword
 
   const createdUser = await prisma.user.create({
-    data: newUser,
-    omit: { password: true }
+    data: newUser
   })
 
-  res.json(createdUser)
+  const { password: _, ...userData } = createdUser
+
+  res.json(userData)
 }


### PR DESCRIPTION
## Summary
- correct typo in `auth.controller.js` import
- adjust user retrieval Prisma queries to exclude passwords

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858c5b90c4c832bbbb75a62350b35f9